### PR TITLE
Default I2C addresses for BG modules

### DIFF
--- a/examples/potentiometer.py
+++ b/examples/potentiometer.py
@@ -6,9 +6,15 @@ import ioexpander as io
 
 print("""potentiometer.py
 
+Change the I2C_ADDR to:
+ - 0x0E to use with the Potentiometer breakout.
+ - 0x18 to use with IO Expander.
+
 Press Ctrl+C to exit.
 
 """)
+
+I2C_ADDR = 0x0E  # 0x18 for IO Expander, 0x0E for the potentiometer breakout
 
 PIN_RED = 1
 PIN_GREEN = 7
@@ -21,7 +27,7 @@ POT_ENC_C = 11
 BRIGHTNESS = 0.5                # Effectively the maximum fraction of the period that the LED will be on
 PERIOD = int(255 / BRIGHTNESS)  # Add a period large enough to get 0-255 steps at the desired brightness
 
-ioe = io.IOE(i2c_addr=0x11)
+ioe = io.IOE(i2c_addr=I2C_ADDR)
 
 ioe.set_mode(POT_ENC_A, io.PIN_MODE_PP)
 ioe.set_mode(POT_ENC_B, io.PIN_MODE_PP)

--- a/examples/rotary.py
+++ b/examples/rotary.py
@@ -6,9 +6,15 @@ import ioexpander as io
 
 print("""rotary.py
 
+Change the I2C_ADDR to:
+ - 0x0F to use with the Rotary Encoder breakout.
+ - 0x18 to use with IO Expander.
+
 Press Ctrl+C to exit.
 
 """)
+
+I2C_ADDR = 0x0F  # 0x18 for IO Expander, 0x0F for the encoder breakout
 
 PIN_RED = 1
 PIN_GREEN = 7
@@ -21,9 +27,11 @@ POT_ENC_C = 11
 BRIGHTNESS = 0.5                # Effectively the maximum fraction of the period that the LED will be on
 PERIOD = int(255 / BRIGHTNESS)  # Add a period large enough to get 0-255 steps at the desired brightness
 
-ioe = io.IOE(i2c_addr=0x18, interrupt_pin=4)
+ioe = io.IOE(i2c_addr=I2C_ADDR, interrupt_pin=4)
 
-ioe.enable_interrupt_out(pin_swap=True)
+# Swap the interrupt pin for the Rotary Encoder breakout
+if I2C_ADDR == 0x0F:
+    ioe.enable_interrupt_out(pin_swap=True)
 
 ioe.setup_rotary_encoder(1, POT_ENC_A, POT_ENC_B, pin_c=POT_ENC_C)
 


### PR DESCRIPTION
Fixes the I2C addresses in potentiometer.py and rotary.py to be the defaults for the new IO-expander based breakout modules (rotary is `0x0F`, pot is `0x0E`)

- https://shop.pimoroni.com/products/rgb-potentiometer-breakout
