### PR TITLE
Fix mics6814 i2c addres and heater enable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [2.7, 3.4, 3.5, 3.7, 3.8]
+        python: [2.7, 3.5, 3.7, 3.9]
 
     steps:
       - uses: actions/checkout@v2
@@ -32,6 +32,6 @@ jobs:
         working-directory: library
         run: |
           python -m pip install coveralls
-          coveralls
-        if: ${{ matrix.python == '3.8' }}
+          coveralls --service github
+        if: ${{ matrix.python == '3.9' }}
 

--- a/examples/mics6814.py
+++ b/examples/mics6814.py
@@ -3,7 +3,7 @@ from colorsys import hsv_to_rgb
 import ioexpander as io
 
 
-ioe = io.IOE(i2c_addr=0x18)
+ioe = io.IOE(i2c_addr=0x19)
 chip_id = ioe.get_chip_id()
 
 print("Chip ID: {:04x}".format(chip_id))
@@ -18,7 +18,7 @@ ioe.set_mode(12, io.ADC)  # P0.5 AIN4 - Red
 ioe.set_mode(11, io.ADC)  # P0.6 AIN3 - NH3
 ioe.set_mode(13, io.ADC)  # P0.7 AIN2 - OX
 
-ioe.set_mode(1, io.OUT)   # P1.5 Heater Enable
+ioe.set_mode(1, io.PIN_MODE_OD)   # P1.5 Heater Enable
 ioe.output(1, io.LOW)
 
 last_heater = 0
@@ -52,4 +52,4 @@ while True:
 
     print(ref, red, nh3, oxd)
 
-    time.sleep(1.0 / 30)
+    time.sleep(1.0)

--- a/library/ioexpander/__init__.py
+++ b/library/ioexpander/__init__.py
@@ -350,7 +350,7 @@ class IOE():
         """Read a single (8bit) register from the device."""
         msg_w = i2c_msg.write(self._i2c_addr, [reg])
         msg_r = i2c_msg.read(self._i2c_addr, 1)
-        self._i2c_dev.i2c_rdwr(msg_w,msg_r)
+        self._i2c_dev.i2c_rdwr(msg_w, msg_r)
 
         return list(msg_r)[0]
 
@@ -688,9 +688,9 @@ class IOE():
         else:
             if value == LOW:
                 if self._debug:
-                    print("Outputting LOW to pin: {pin}".format(pin=pin, value=value))
+                    print("Outputting LOW to pin: {pin}".format(pin=pin))
                 self.clr_bit(io_pin.reg_p, io_pin.pin)
             elif value == HIGH:
                 if self._debug:
-                    print("Outputting HIGH to pin: {pin}".format(pin=pin, value=value))
+                    print("Outputting HIGH to pin: {pin}".format(pin=pin))
                 self.set_bit(io_pin.reg_p, io_pin.pin)

--- a/library/tox.ini
+++ b/library/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,37},qa
+envlist = py{27,35,37,39},qa
 skip_missing_interpreters = True
 
 [testenv]
@@ -14,7 +14,7 @@ deps =
 
 [testenv:qa]
 commands =
-	check-manifest --ignore tox.ini,tests*,.coveragerc
+	check-manifest --ignore tox.ini,tests/*,.coveragerc
 	python setup.py sdist bdist_wheel
 	twine check dist/*
 	flake8 --ignore E501


### PR DESCRIPTION
While testing with Pico I noticed a flat response, and I believe the heater either was not being enabled, or the drive strength of the "OUT" mode GPIO pin was not sufficient enough to fully enable it.

This change hopefully gives the heater_en pin a little more oomph and additionally corrects the i2c address.

Tested with alcohol, the response time is *very* slow taking on the order of seconds to reach a stable temperature and respond to the introduction of alcohol. Maybe I need some *full* gin bottles.