### PR TITLE
Add switch counter support

### DIFF
--- a/library/tests/conftest.py
+++ b/library/tests/conftest.py
@@ -13,7 +13,10 @@ def cleanup():
     """
 
     yield None
-    del sys.modules["ioexpander"]
+    try:
+        del sys.modules["ioexpander"]
+    except KeyError:
+        pass
 
 
 @pytest.fixture(scope='function', autouse=False)
@@ -25,3 +28,10 @@ def smbus2():
     sys.modules['smbus2'] = smbus2
     yield smbus2
     del sys.modules['smbus2']
+
+
+@pytest.fixture(scope='function')
+def ioe():
+    from ioexpander import IOE
+    yield IOE(skip_chip_id_check=True)
+    del sys.modules["ioexpander"]

--- a/library/tests/test_switch_counter.py
+++ b/library/tests/test_switch_counter.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+def test_setup_switch_counter(smbus2, ioe):
+    ioe.setup_switch_counter(1)
+
+
+def test_read_switch_counter(smbus2, ioe):
+    smbus2.i2c_msg.read().__iter__.return_value = [0b10000010]
+    assert ioe.read_switch_counter(1) == (2, True)
+
+    smbus2.i2c_msg.read().__iter__.return_value = [0b00000010]
+    assert ioe.read_switch_counter(1) == (2, False)
+
+
+def test_switch_counter_invalid_pin(smbus2, ioe):
+    with pytest.raises(ValueError):
+        ioe.setup_switch_counter(10)
+
+    with pytest.raises(ValueError):
+        ioe.read_switch_counter(10)


### PR DESCRIPTION
Add support for the 7-bit switch/pulse counters for rain sensors & anemometers.

Replaces previous attempt from https://github.com/pimoroni/ioe-python/commit/a45e5a84a9ae1dfc3f40a7e5c72ff116ab3385e9 since this is slightly nicer.